### PR TITLE
Support CUDA 11 + linux fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,19 @@ endif()
 
 set(TCNN_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
 
-find_package(CUDA 12.0 REQUIRED)
+# Prefer CUDA 12, but use 11 if 12 not available
+find_package(CUDA 12 QUIET)
+if(NOT CUDA_FOUND)
+    find_package(CUDA 11 QUIET)
+    if(NOT CUDA_FOUND)
+        message(FATAL_ERROR "CUDA 12 (or 11) not found!")
+    else()
+        message(STATUS "Using CUDA 11 from ${CUDA_TOOLKIT_ROOT_DIR}")
+    endif()    
+else()
+    message(STATUS "Using CUDA 12 from ${CUDA_TOOLKIT_ROOT_DIR}")
+endif()
+
 include_directories(${CUDA_INCLUDE_DIRS})
 
 # OpenGL

--- a/patches/glad-pic.patch
+++ b/patches/glad-pic.patch
@@ -1,0 +1,12 @@
+diff --git a/includes/glad/CMakeLists.txt b/includes/glad/CMakeLists.txt
+index 36de7e0..fe5ad43 100644
+--- a/includes/glad/CMakeLists.txt
++++ b/includes/glad/CMakeLists.txt
+@@ -13,3 +13,5 @@ set(HEADERS
+ include_directories(include)
+ 
+ add_library(glad STATIC ${SOURCES} ${HEADERS})
++# Linux, Python module, needs -fPIC and friends to link
++set_property(TARGET glad PROPERTY POSITION_INDEPENDENT_CODE ON)
+\ No newline at end of file
+

--- a/patches/pybind11-cuda12.patch
+++ b/patches/pybind11-cuda12.patch
@@ -1,0 +1,15 @@
+diff --git a/include/pybind11/cast.h b/include/pybind11/cast.h
+index 3a404602..9054478c 100644
+--- a/include/pybind11/cast.h
++++ b/include/pybind11/cast.h
+@@ -42,7 +42,9 @@ using make_caster = type_caster<intrinsic_t<type>>;
+ // Shortcut for calling a caster's `cast_op_type` cast operator for casting a type_caster to a T
+ template <typename T>
+ typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {
+-    return caster.operator typename make_caster<T>::template cast_op_type<T>();
++    // https://github.com/pybind/pybind11/issues/4606 with CUDA 12
++    //return caster.operator typename make_caster<T>::template cast_op_type<T>();
++    return caster;
+ }
+ template <typename T>
+ typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>

--- a/patches/tiny-cuda-nn-pic.patch
+++ b/patches/tiny-cuda-nn-pic.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 600bc41..a13a404 100644
+--- includes/tiny-cuda-nn/CMakeLists.txt
++++ includes/tiny-cuda-nn/CMakeLists.txt
+@@ -187,6 +187,8 @@ find_library(
+ )
+ 
+ set(BUILD_SHARED_LIBS OFF)
++# Linux, Python module, needs -fPIC and friends to link
++set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ add_subdirectory("dependencies/fmt")
+ 
+ ###############################################################################
+

--- a/patches/tiny-cuda-nn-pic.patch
+++ b/patches/tiny-cuda-nn-pic.patch
@@ -1,7 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 600bc41..a13a404 100644
---- includes/tiny-cuda-nn/CMakeLists.txt
-+++ includes/tiny-cuda-nn/CMakeLists.txt
+--- a/includes/tiny-cuda-nn/CMakeLists.txt
++++ b/includes/tiny-cuda-nn/CMakeLists.txt
 @@ -187,6 +187,8 @@ find_library(
  )
  

--- a/src/core/nerf-network.cu
+++ b/src/core/nerf-network.cu
@@ -486,7 +486,9 @@ float NerfNetwork::calculate_loss(
 	thrust::device_ptr<float> loss_buffer_ptr(workspace.loss_buf);
 
 	return (1.0f / (float)n_rays) * thrust::reduce(
+#if CUDA_VERSION >= 12000
 		thrust::cuda::par_nosync.on(stream),
+#endif
 		loss_buffer_ptr,
 		loss_buffer_ptr + 4 * batch_size,
 		0.0f,

--- a/src/utils/bit-utils.cu
+++ b/src/utils/bit-utils.cu
@@ -1,4 +1,8 @@
-#pragma once
+//#pragma once
+// error: #pragma once in main file
+#ifndef TURBONERF_BIT_UTILS_CU
+#define TURBONERF_BIT_UTILS_CU
+
 #include "bit-utils.cuh"
 
 TURBO_NAMESPACE_BEGIN
@@ -20,3 +24,5 @@ __global__ void get_1s_per_uint32(
 }
 
 TURBO_NAMESPACE_END
+
+#endif

--- a/src/utils/parallel-utils.cuh
+++ b/src/utils/parallel-utils.cuh
@@ -29,14 +29,18 @@ inline __host__ int find_last_lt_presorted(
 	const size_t& n_elements,
     const T& max_value
 ) {
+#if CUDA_VERSION >= 12000
 	auto exec_policy = thrust::cuda::par_nosync.on(stream);
+#endif
 
 	auto iter_begin_reverse = thrust::make_reverse_iterator(data_begin_ptr);
 	auto iter_end_reverse = thrust::make_reverse_iterator(data_begin_ptr + n_elements);
 
     // find the last element in the vector that is less than the maximum value
     auto last = thrust::find_if(
+#if CUDA_VERSION >= 12000
 		exec_policy,
+#endif        
         iter_end_reverse,
         iter_begin_reverse,
         [max_value] __device__ (T x) { return x < max_value; }


### PR DESCRIPTION
This adds support for CUDA 11, but still checks for CUDA 12 in the main cmake config. The few places in the CUDA code where CUDA12-specific features are used are behind #include guards.

The patches in the patches/ dir need to be applied to the recursively checked out repository, as we need to patches to the glad, tiny-cuda-nn and pybind11 source repos in include/.

The first two are needed as a shared library (and so the Python module) on Linux requires the code in the glad and tiny-cuda-nn library to be built as position-independent code (-fPIC). I did not see the required options to enable this in the upstream code, hence the patches like this. 

The patch to pybind11 is needed when building against CUDA12 to work around https://github.com/pybind/pybind11/issues/4606

Finally, I had an error related to the use of #pragma once, which I worked around using include guards.